### PR TITLE
Fix for incorrect edit button href

### DIFF
--- a/frontend-edit-button.php
+++ b/frontend-edit-button.php
@@ -128,7 +128,8 @@ class FrontendEditButtonPlugin extends Plugin {
 
 		//$pageUrl = $page->url( false, false, true, false );
 		$uri = $this->grav['uri'];
-		$pageUrl = $uri->url(false, false);
+		//$pageUrl = $uri->url(false, false);
+		$pageUrl = $uri->path();
 
 		/* otherwise the home page can't be edited */
 		if ( $pageUrl == '/' ) {


### PR DESCRIPTION
v1.0.5 here with Grav 1.3.10.

I found that the href for the edit button was incorrect - when I clicked the edit button for page `http://server/subdir/thepage` the button redirected to `http://server/subdir/admin/pages/subdir/thepage`. The PR fixes this (at least for me) by setting `$pageUrl = $uri->path();`. Can you review please? Thanks, Nick